### PR TITLE
Use the correct JSX attribute autoComplete

### DIFF
--- a/client/src/components/AddUserForm.jsx
+++ b/client/src/components/AddUserForm.jsx
@@ -33,7 +33,7 @@ const AddUserForm = ({ hideForm }) => {
               type="text"
               name="username"
               required="required"
-              autocomplete="off"
+              autoComplete="off"
               value={username}
               placeholder="New user name"
               onChange={e => setUsername(e.target.value)}


### PR DESCRIPTION
Any time the "Add a new user" card was shown, the following error message would appear in the developer tools console:

```
Warning: Invalid DOM property `autocomplete`. Did you mean `autoComplete`?
```

It turns out that the camelCased `autoComplete` is the correct JSX attribute to use ([link](https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes)). While this didn't seem to have any negative impact, the big error message could be distracting for developers looking at the console while interacting with the app. I've updated the attribute and confirmed that the error message is no longer present when adding a new user.