### PR TITLE
Drop null constraint on link_session_id

### DIFF
--- a/database/init/create.sql
+++ b/database/init/create.sql
@@ -192,7 +192,7 @@ CREATE TABLE link_events_table
   id SERIAL PRIMARY KEY,
   type text NOT NULL,
   user_id integer,
-  link_session_id text NOT NULL,
+  link_session_id text,
   request_id text UNIQUE,
   error_type text,
   error_code text,


### PR DESCRIPTION
link_session_id can be null in some cases, for example if link fails to initialize due to a 400/500 on `/link/client/get`. this schema was a bit optimistic