### PR TITLE
Removing PLAID_PUBLIC_KEY from .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,7 +2,6 @@
 # https://dashboard.plaid.com/account/keys
 
 PLAID_CLIENT_ID=
-PLAID_PUBLIC_KEY=
 PLAID_SECRET_DEVELOPMENT=
 PLAID_SECRET_SANDBOX=
 


### PR DESCRIPTION
Removed the `PLAID_PUBLIC_KEY` reference from our .env.template to align with the `link_token` update.

No testing is required for this change. 