### PR TITLE
add check for redirect uri

### DIFF
--- a/server/routes/linkTokens.js
+++ b/server/routes/linkTokens.js
@@ -48,8 +48,11 @@ router.post(
         language: 'en',
         webhook: httpTunnel.public_url + '/services/webhook',
         access_token: accessToken,
-        redirect_uri: redirect_uri,
       };
+      // If user has entered a redirect uri in the .env file
+      if (redirect_uri.length > 1) {
+        linkTokenParams.redirect_uri = redirect_uri;
+      }
       const createResponse = await plaid.linkTokenCreate(linkTokenParams);
       res.json(createResponse.data);
     } catch (err) {


### PR DESCRIPTION
Adds check so that user does not have to enter a redirect uri in .env file if they don't want to test Oauth.