### PR TITLE
clarify Oauth testing in development

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,9 +19,10 @@ PLAID_ENV=sandbox
 # this redirect URI for your client ID through the Plaid developer dashboard
 # at https://dashboard.plaid.com/team/api.
 # Development mode:
-# When running in development mode, you must use an https://.  In this case,
-# set the PLAID_DEVELOPMENT_REDIRECT_URI to 'https://localhost:3001/oauth-link'.
+# When running in development mode, you must use an https://.
 # You will need to configure this https:// redirect URI in the Plaid developer dashboard.
+# If your system is not set up to run localhost with https://, you will be unable to test
+# the OAuth in development and should leave the PLAID_DEVELOPMENT_REDIRECT_URI blank.
 
 PLAID_SANDBOX_REDIRECT_URI=
 PLAID_DEVELOPMENT_REDIRECT_URI=

--- a/.env.template
+++ b/.env.template
@@ -19,7 +19,7 @@ PLAID_ENV=sandbox
 # this redirect URI for your client ID through the Plaid developer dashboard
 # at https://dashboard.plaid.com/team/api.
 # Development mode:
-# When running in development mode, you must use an https://.
+# When running in development mode, you must use an https:// url.
 # You will need to configure this https:// redirect URI in the Plaid developer dashboard.
 # If your system is not set up to run localhost with https://, you will be unable to test
 # the OAuth in development and should leave the PLAID_DEVELOPMENT_REDIRECT_URI blank.


### PR DESCRIPTION
add language to .env.template that states that you need https:// for development or leave it blank.