### PR TITLE
change link token creation flow

### DIFF
--- a/client/src/components/ItemCard.tsx
+++ b/client/src/components/ItemCard.tsx
@@ -5,7 +5,7 @@ import { Institution } from 'plaid/dist/api';
 
 import { ItemType, AccountType, AppFundType } from './types';
 import { AccountCard, MoreDetails } from '.';
-import { useAccounts, useInstitutions, useItems } from '../services';
+import { useAccounts, useInstitutions, useItems, useLink } from '../services';
 import { setItemToBadState, getBalanceByItem } from '../services/api';
 import { diffBetweenCurrentTime } from '../util';
 
@@ -41,6 +41,7 @@ const ItemCard = (props: Props) => {
     getInstitutionById,
     formatLogoSrc,
   } = useInstitutions();
+  const { deleteLinkToken } = useLink();
   const { id, plaid_institution_id, status } = props.item;
   const isSandbox = PLAID_ENV === 'sandbox';
   const isGoodState = status === 'good';
@@ -68,6 +69,7 @@ const ItemCard = (props: Props) => {
   const handleDeleteItem = () => {
     deleteItemById(id, props.userId);
     deleteAccountsByItemId(id);
+    deleteLinkToken(props.userId);
   };
   const account = accounts[0];
   return (

--- a/client/src/components/LinkButton.tsx
+++ b/client/src/components/LinkButton.tsx
@@ -104,7 +104,18 @@ export default function LinkButton(props: Props) {
     if (props.isOauth && ready) {
       open();
     }
-  }, [ready, open, props.isOauth]);
+    if (props.itemId == null && ready) {
+      localStorage.setItem(
+        'oauthConfig',
+        JSON.stringify({
+          userId: props.userId,
+          itemId: props.itemId,
+          token: props.token,
+        })
+      );
+      open();
+    }
+  }, [ready, open, props.isOauth, props.userId, props.itemId, props.token]);
 
   const handleClick = () => {
     // regular, non-OAuth case:
@@ -140,17 +151,7 @@ export default function LinkButton(props: Props) {
         </Touchable>
       ) : (
         // regular case for initializing Link from user card or from "add another item" button
-        <Button
-          disabled={!ready}
-          className="linkButton"
-          large
-          inline
-          onClick={() => {
-            handleClick();
-          }}
-        >
-          {props.children}
-        </Button>
+        <></>
       )}
     </>
   );

--- a/client/src/components/UserCard.tsx
+++ b/client/src/components/UserCard.tsx
@@ -23,6 +23,10 @@ export default function UserCard(props: Props) {
   const { deleteUserById } = useUsers();
   const { generateLinkToken, linkTokens } = useLink();
 
+  const initiateLink = async () => {
+    await generateLinkToken(props.userId, null);
+  };
+
   // update data store with the user's items
   useEffect(() => {
     if (props.userId) {
@@ -39,13 +43,12 @@ export default function UserCard(props: Props) {
     }
   }, [itemsByUser, props.userId]);
 
-  // creates new link token upon change in user or number of items
   useEffect(() => {
-    generateLinkToken(props.userId, null); // itemId is null
-  }, [props.userId, generateLinkToken]);
-
-  useEffect(() => {
-    setToken(linkTokens.byUser[props.userId]);
+    if (numOfItems === 0) {
+      setToken(linkTokens.byUser[props.userId]);
+    } else {
+      setToken('');
+    }
   }, [linkTokens, props.userId, numOfItems]);
 
   const handleDeleteUser = () => {
@@ -80,12 +83,15 @@ export default function UserCard(props: Props) {
               </div>
             </Touchable>
           </div>
+          {numOfItems === 0 && (
+            <Button onClick={initiateLink}>
+              Add your checking or savings account
+            </Button>
+          )}
           {(props.removeButton || (props.linkButton && numOfItems === 0)) && (
             <div className="user-card__buttons">
               {token != null && token.length > 0 && props.linkButton && (
-                <LinkButton userId={props.userId} token={token} itemId={null}>
-                  Add your checking or savings account
-                </LinkButton>
+                <LinkButton userId={props.userId} token={token} itemId={null} />
               )}
               {props.removeButton && (
                 <Button

--- a/client/src/services/link.tsx
+++ b/client/src/services/link.tsx
@@ -33,7 +33,8 @@ type LinkAction =
       token: string;
     }
   | { type: 'LINK_TOKEN_UPDATE_MODE_CREATED'; id: number; token: string }
-  | { type: 'LINK_TOKEN_ERROR'; error: PlaidLinkError };
+  | { type: 'LINK_TOKEN_ERROR'; error: PlaidLinkError }
+  | { type: 'DELETE_LINK_TOKEN'; id: number };
 
 interface LinkContextShape extends LinkState {
   dispatch: Dispatch<LinkAction>;
@@ -41,6 +42,7 @@ interface LinkContextShape extends LinkState {
     userId: number,
     itemId: number | null | undefined
   ) => void;
+  deleteLinkToken: (userId: number) => void;
   linkTokens: LinkState;
 }
 const LinkContext = createContext<LinkContextShape>(
@@ -79,12 +81,20 @@ export function LinkProvider(props: any) {
     }
   }, []);
 
+  const deleteLinkToken = useCallback(async userId => {
+    dispatch({
+      type: 'DELETE_LINK_TOKEN',
+      id: userId,
+    });
+  }, []);
+
   const value = useMemo(
     () => ({
       generateLinkToken,
+      deleteLinkToken,
       linkTokens,
     }),
-    [linkTokens, generateLinkToken]
+    [linkTokens, generateLinkToken, deleteLinkToken]
   );
 
   return <LinkContext.Provider value={value} {...props} />;
@@ -111,6 +121,13 @@ function reducer(state: any, action: LinkAction) {
         byItem: {
           ...state.byItem,
           [action.id]: action.token,
+        },
+      };
+    case 'DELETE_LINK_TOKEN':
+      return {
+        ...state,
+        byUser: {
+          [action.id]: '',
         },
       };
     case 'LINK_TOKEN_ERROR':


### PR DESCRIPTION
Instead of creating the link token when a user gets created, this PR changes the flow so that the link token creation does not occur until the enduser clicks to add a bank.  It also deletes the old link token from the context when an item is deleted.  