### PR TITLE
Change server port when using Docker from 5000 to 5001

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -59,5 +59,5 @@
     "immer": "9.0.6",
     "glob-parent": "5.1.2"
   },
-  "proxy": "http://server:5000"
+  "proxy": "http://server:5001"
 }

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -16,7 +16,7 @@ services:
       - ./server:/opt/server
       - server_node_modules:/opt/server/node_modules
     ports:
-      - 5000:5000
+      - 5001:5001
       - 9229:9229
 
   ngrok:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build: ./server
     image: plaidinc/pattern-server:1.0.7
     ports:
-      - 5000:5000
+      - 5001:5001
     environment:
       <<: *common-variables
       PLAID_CLIENT_ID:
@@ -31,7 +31,7 @@ services:
       PLAID_SANDBOX_REDIRECT_URI:
       PLAID_DEVELOPMENT_REDIRECT_URI:
       PLAID_ENV:
-      PORT: 5000
+      PORT: 5001
       DB_PORT: 5432
       DB_HOST_NAME: db
     depends_on:
@@ -40,7 +40,7 @@ services:
   ngrok:
     build: ./ngrok
     image: plaidinc/pattern-ngrok:1.0.7
-    command: ["ngrok", "http", "server:5000"]
+    command: ["ngrok", "http", "server:5001"]
     ports:
       - 4040:4040
     depends_on:
@@ -53,6 +53,6 @@ services:
       - 3001:3001
     environment:
       REACT_APP_PLAID_ENV: ${PLAID_ENV}
-      REACT_APP_SERVER_PORT: 5000
+      REACT_APP_SERVER_PORT: 5001
     depends_on:
       - server


### PR DESCRIPTION
## What

Changes the server port from `5000` to `50001` when using Docker.

## Why

On macOS, port 5000 is already in use by the macOS Command Center.

5001 was chosen because it mirrors the use of port 3001 for the frontend.

Resolves #253