### PR TITLE
Fix deleteItem query

### DIFF
--- a/server/db/queries/items.js
+++ b/server/db/queries/items.js
@@ -153,7 +153,7 @@ const updateItemStatus = async (itemId, status) => {
  */
 const deleteItem = async itemId => {
   const query = {
-    text: `DELETE FROM items_table WHERE plaid_item_id = $1`,
+    text: `DELETE FROM items_table WHERE id = $1`,
     values: [itemId],
   };
   await db.query(query);


### PR DESCRIPTION
## Description

Deleting item was not working as `deleteItem()` query was comparing item's id with plaid item id. i.e. itemId passed into `deleteItem()` was not a plaid item id. This reulsted in a falsely successful response without actually deleting the item, its associated accounts, and transactions.


## How to test

1. Go to users page
2. Link an account (create an item)
3. Remove an item (bank/institution)
4. See it's removed