### PR TITLE
docker updates

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,8 +10,11 @@ PLAID_SECRET_SANDBOX=
 
 PLAID_ENV=sandbox
 
-# Only required for OAuth:
+# IMPORTANT: Also update ngrok.yml in the /ngrok directory to add your authtoken
 
+
+# (Optional) Redirect URI settings section
+# Only required for OAuth redirect URI testing (not common on desktop):
 # Sandbox Mode:
 # Set the PLAID_SANDBOX_REDIRECT_URI below to 'http://localhost:3001/oauth-link'.
 # The OAuth redirect flow requires an endpoint on the developer's website

--- a/Makefile
+++ b/Makefile
@@ -29,36 +29,36 @@ help:
 ## Start the services
 start: $(envfile) $(clear_db_after_schema_change)
 	@echo "Pulling images from Docker Hub (this may take a few minutes)"
-	docker-compose pull
+	docker compose pull
 	@echo "Starting Docker services"
-	docker-compose up --build --detach
+	docker compose up --build --detach
 	./wait-for-client.sh
 
 ## Start the services without webhooks
 start-no-webhooks: $(envfile) $(clear_db_after_schema_change)
 	@echo "Pulling images from Docker Hub (this may take a few minutes)"
-	docker-compose pull
+	docker compose pull
 	@echo "Starting Docker services"
-	docker-compose up --detach client
+	docker compose up --detach client
 	./wait-for-client.sh
 
 ## Start the services in debug mode
 debug: $(envfile) $(clear_db_after_schema_change)
 	@echo "Starting services (this may take a few minutes if there are any changes)"
-	docker-compose -f docker-compose.yml -f docker-compose.debug.yml up --build --detach
+	docker compose -f docker-compose.yml -f docker-compose.debug.yml up --build --detach
 	./wait-for-client.sh
 
 ## Start an interactive psql session (services must running)
 sql:
-	docker-compose exec db psql -U postgres
+	docker compose exec db psql -U postgres
 
 ## Show the service logs (services must be running)
 logs:
-	docker-compose logs --follow
+	docker compose logs --follow
 
 ## Stop the services
 stop:
-	docker-compose down
+	docker compose down
 	docker volume rm $(current_dir)_{client,server}_node_modules 2>/dev/null || true
 
 ## Clear the sandbox and development databases

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Plaid Pattern apps are provided for illustrative purposes and are not meant to b
 
 -   [Docker][docker] Version 2.0.0.3 (31259) or higher, installed, running, and signed in. If you're on **Windows**, check out [this link][wsl] to get set up in WSL.
 -   [Plaid API keys][plaid-keys] - [sign up][plaid-signup] for a free Sandbox account if you don't already have one
--   Sign up for an NGROK account and obtain an authtoken. 
+-   [Sign up for a free ngrok account](https://dashboard.ngrok.com/signup) to obtain an authtoken
 
 ## Getting Started
 
@@ -36,9 +36,9 @@ Note: We recommend running these commands in a unix terminal. Windows users can 
     ```
 1. Update the `.env` file with your [Plaid API keys][plaid-keys] and OAuth redirect uri (in sandbox this is 'http<span>://localhost:3001/oauth-link'</span>).
 
-2. Update the ngrok.yml file in the ngrok folder with your authtoken. Add this below the web_addr line. The format should be authtoken: XXX  where XXX is your token for your account.
+2. Update the `ngrok.yml` file in the ngrok folder with your ngrok authtoken. 
 
-1. You will also need to configure an allowed redirect URI for your client ID through the [Plaid developer dashboard](https://dashboard.plaid.com/team/api).
+1. (Optional, only required if testing OAuth with redirect URIs) You will also need to configure an allowed redirect URI for your client ID through the [Plaid developer dashboard](https://dashboard.plaid.com/team/api).
 
 1. Start the services. The first run may take a few minutes as Docker images are pulled/built for the first time.
     ```shell

--- a/ngrok/ngrok.yml
+++ b/ngrok/ngrok.yml
@@ -1,1 +1,3 @@
 web_addr: 0.0.0.0:4040
+## Fill this in with your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
+authtoken: 

--- a/ngrok/ngrok.yml
+++ b/ngrok/ngrok.yml
@@ -1,3 +1,3 @@
 web_addr: 0.0.0.0:4040
-## Fill this in with your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
+# Fill this in with your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
 authtoken: 


### PR DESCRIPTION
Updates:

- Slight improvements to make the instructions in https://github.com/plaid/pattern/pull/282 easier to follow
- Similar to the other series of PRs I'm making, replace docker-compose with docker compose b/c docker-compose is no longer supported for new downloads
- Clarify OAuth redirect uri instructions similar to how we did for the quickstart