### PR TITLE
fix item updates

### DIFF
--- a/server/db/queries/items.js
+++ b/server/db/queries/items.js
@@ -126,7 +126,7 @@ const retrieveItemsByUser = async userId => {
  */
 const updateItemStatus = async (itemId, status) => {
   const query = {
-    text: 'UPDATE items SET status = $1 WHERE plaid_item_id = $2',
+    text: 'UPDATE items SET status = $1 WHERE id = $2',
     values: [status, itemId],
   };
   await db.query(query);
@@ -135,13 +135,13 @@ const updateItemStatus = async (itemId, status) => {
 /**
  * Updates the transaction cursor for a single item.
  *
- * @param {string} itemId the Plaid item ID of the item.
+ * @param {string} plaidItemId the Plaid item ID of the item.
  * @param {string} transactionsCursor latest observed transactions cursor on this item.
  */
- const updateItemTransactionsCursor = async (itemId, transactionsCursor) => {
+ const updateItemTransactionsCursor = async (plaidItemId, transactionsCursor) => {
   const query = {
     text: 'UPDATE items SET transactions_cursor = $1 WHERE plaid_item_id = $2',
-    values: [transactionsCursor, itemId],
+    values: [transactionsCursor, plaidItemId],
   };
   await db.query(query);
 };


### PR DESCRIPTION
Reported in the Discord community.

This issue was introduced by https://github.com/plaid/pattern/pull/245 which I introduced by approving this PR without thinking about it. It turns out you can't just change the key used by a SQL query without changing any of callsites and have it work, as a matter of fact. Who knew???? The original PR changed 3 queries.

This was partially fixed by https://github.com/plaid/pattern/pull/274 which fixed one query.

This PR fixes the second query.

There is a third query, updateItemTransactionsCursor, which is kind of interesting, and maybe the reason why https://github.com/plaid/pattern/pull/245 worked. In the original code that migrated Pattern to sync, there was a legitimate bug in updateItemTransactionsCursor, in that it was called by updateTransactions using an ItemId when updateTransactions didn't have an ItemId, only a plaidItemId. (Why did we decide to have a primary key in the first place that was separate from the item ID??)

https://github.com/plaid/pattern/pull/243 fixed that callsite to match the plaid_item_id. 

This PR also clarifies that updateItemTransactionsCursor takes a PlaidItemId, not an ItemId. 

I haven't yet tested this because I am sick of looking at it, but I will before I merge, or maybe you can test it. 