### PR TITLE
Small Fix: transaction cursor was pointing to wrong reference

### DIFF
--- a/server/update_transactions.js
+++ b/server/update_transactions.js
@@ -24,7 +24,7 @@ const fetchTransactionUpdates = async (plaidItemId) => {
   // get the access token based on the plaid item id
   const {
     plaid_access_token: accessToken,
-    last_transactions_update_cursor: lastCursor,
+    transactions_cursor: lastCursor,
   } = await retrieveItemByPlaidItemId(
     plaidItemId
   );


### PR DESCRIPTION
Appreciate providing the pattern template to be able to interact with Plaid. I have used it and works great.

This PR is a small fix that changes the server `retrieveItemByPlaidItemId` method to use the correct cursor object so that the updates can `remove` and `modify` transactions. current it only `adds`.