### PR TITLE
upgrade ngrok agent

### DIFF
--- a/ngrok/Dockerfile
+++ b/ngrok/Dockerfile
@@ -14,9 +14,9 @@ RUN set -x && \
 RUN set -x \
     # Install ngrok (latest official stable from https://ngrok.com/download).
     && apk add --no-cache curl \
-    && curl -Lo /ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip \
-    && unzip -o /ngrok.zip -d /bin \
-    && rm -f /ngrok.zip \
+    && curl -Lo /ngrok.tgz https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-arm64.tgz \
+    && tar xvzf /ngrok.tgz -C /bin \
+    && rm -f /ngrok.tgz \
     # Create non-root user.
     && adduser -h /home/ngrok -D -u 6737 ngrok
 RUN ngrok --version

--- a/ngrok/ngrok.yml
+++ b/ngrok/ngrok.yml
@@ -1,3 +1,4 @@
 web_addr: 0.0.0.0:4040
 # Fill this in with your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
 authtoken: 
+version: 2

--- a/server/routes/linkTokens.js
+++ b/server/routes/linkTokens.js
@@ -35,7 +35,7 @@ router.post(
       }
       const response = await fetch('http://ngrok:4040/api/tunnels');
       const { tunnels } = await response.json();
-      const httpTunnel = tunnels.find(t => t.proto === 'http');
+      const httpsTunnel = tunnels.find(t => t.proto === 'https');
       const linkTokenParams = {
         user: {
           // This should correspond to a unique id for the current user.
@@ -45,7 +45,7 @@ router.post(
         products,
         country_codes: ['US'],
         language: 'en',
-        webhook: httpTunnel.public_url + '/services/webhook',
+        webhook: httpsTunnel.public_url + '/services/webhook',
         access_token: accessToken,
       };
       // If user has entered a redirect uri in the .env file


### PR DESCRIPTION
Fixes https://github.com/plaid/pattern/issues/298

ngrok has recently dropped support for ngrok agent 2 for non-paying users and is requiring all free tier users to upgrade to ngrok 3.

This PR upgrades from ngrok 2 to ngrok 3 and accommodates the following breaking changes in ngrok 3:
- The config file must have a `version` parameter
- All tunnels are by default over https rather than http

Once this is approved, I will apply the same change to the other sample apps that use ngrok.