### PR TITLE
Replace plaid-threads with Tailwind CSS

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,13 +8,13 @@
       "name": "client",
       "version": "1.0.7",
       "dependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
         "axios": "^1.13.5",
         "date-fns": "^4.1.0",
         "immer": "10.2.0",
         "plaid": "^41.1.0",
-        "plaid-threads": "14.5.0",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -24,7 +24,8 @@
         "react-toastify": "^10.0.6",
         "recharts": "^2.15.0",
         "sass": "^1.97.3",
-        "socket.io-client": "^4.8.3"
+        "socket.io-client": "^4.8.3",
+        "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
         "@types/lodash": "^4.17.13",
@@ -40,91 +41,6 @@
         "vite": "^8.0.8"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -134,56 +50,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -195,7 +65,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -206,126 +75,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.3.3",
-        "babel-plugin-macros": "^3.1.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -471,31 +225,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -572,6 +301,16 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -601,7 +340,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -620,7 +358,6 @@
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
       "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -935,16 +672,6 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -961,7 +688,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -978,7 +704,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -995,7 +720,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1012,7 +736,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1029,7 +752,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1046,7 +768,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,7 +784,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1080,7 +800,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,7 +816,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1114,7 +832,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,7 +848,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1148,7 +864,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,7 +880,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1184,7 +898,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1201,7 +914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1224,11 +936,267 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1330,17 +1298,11 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -1400,15 +1362,6 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-dom": "^5.3.0"
-      }
-    },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/socket.io-client": {
@@ -1471,15 +1424,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/add-dom-event-listener": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz",
-      "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "4.x"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1537,31 +1481,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1597,6 +1516,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1633,12 +1553,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -1681,65 +1595,12 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/component-classes": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
-      "integrity": "sha512-hPFGULxdwugu1QWW3SvVOCUHLzO34+a2J6Wqy0c5ASQkfi9/8nZcBB0ZohaEbXOQlCflMAEMmEWk7u7BVs4koA==",
-      "license": "MIT",
-      "dependencies": {
-        "component-indexof": "0.0.3"
-      }
-    },
-    "node_modules/component-indexof": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
-      "integrity": "sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw=="
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1754,16 +1615,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-animation": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
-      "integrity": "sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "component-classes": "^1.2.5"
       }
     },
     "node_modules/csstype": {
@@ -1946,17 +1797,10 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dom-align": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
-      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
-      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -2004,13 +1848,17 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "license": "MIT",
       "dependencies": {
-        "is-arrayish": "^0.2.1"
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2062,6 +1910,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2261,12 +2110,6 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
-    "node_modules/exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2308,7 +2151,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2334,12 +2176,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2378,29 +2214,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/focus-trap": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
-      "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
-      "license": "MIT",
-      "dependencies": {
-        "tabbable": "^5.3.3"
-      }
-    },
-    "node_modules/focus-trap-react": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.11.3.tgz",
-      "integrity": "sha512-y126gMYuB1aVYiEZSP6/v9bAfVmAIUVixanhcoMelkz7bOh+l0c3h05CEHC8S63ztxdRI2AAPS9AsTat6jlDeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "focus-trap": "^6.9.4"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.8.1",
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -2442,7 +2255,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2537,6 +2349,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2586,31 +2404,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highcharts": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.3.3.tgz",
-      "integrity": "sha512-r7wgUPQI9tr3jFDn3XT36qsNwEIZYcfgz4mkKEA6E4nn5p86y+u1EZjazIG4TRkl5/gmGRtkBUiZW81g029RIw==",
-      "license": "https://www.highcharts.com/license"
-    },
-    "node_modules/highcharts-react-official": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.2.3.tgz",
-      "integrity": "sha512-2gL8bVGe6Pf75tSe6IB5Ucd0nIOJX7ZrpttQBZVrjN2J9StdVZ12aOinXHIOFvlc6EzP8CbN13WS8NUq+9mptA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "highcharts": ">=6.0.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2641,6 +2434,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -2670,27 +2464,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -2723,6 +2496,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2742,29 +2524,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -2805,17 +2569,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/libphonenumber-js": {
-      "version": "1.9.52",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.52.tgz",
-      "integrity": "sha512-8k83chc+zMj+J/RkaBxi0PpSTAdzHmpqzCMqquSJVRfbZFr8DCp6vPC7ms2PIPGxeqajZLI6CBLW5nLCJCJrYg==",
-      "license": "MIT"
-    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -2848,7 +2605,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2869,7 +2625,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2890,7 +2645,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2911,7 +2665,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2932,7 +2685,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2953,7 +2705,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2974,7 +2725,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2995,7 +2745,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3016,7 +2765,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3037,7 +2785,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3058,7 +2805,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3071,12 +2817,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3119,6 +2859,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3127,12 +2876,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/memoize-one": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
-      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -3168,27 +2911,6 @@
         "node": "*"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.48",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
-      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
-      "license": "MIT",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3199,7 +2921,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3291,30 +3012,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -3337,27 +3041,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3368,7 +3051,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3389,50 +3071,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/plaid-threads": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/plaid-threads/-/plaid-threads-14.5.0.tgz",
-      "integrity": "sha512-/iKGCYDFsnFG72fEPEad1d27wZe4PPPXfG0gwSv6t3NZpeFFKknC9pHNz09uKR2K8+5A3DYI/RkdcqoFR3EQfA==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@popperjs/core": "^2.4.4",
-        "classnames": "^2.2.6",
-        "focus-trap-react": "^8.11.1",
-        "highcharts": "^10.2.0",
-        "highcharts-react-official": "^3.1.0",
-        "libphonenumber-js": "1.9.52",
-        "moment-timezone": "^0.5.39",
-        "prism-react-renderer": "^1.0.2",
-        "rc-calendar": "^9.15.11",
-        "react-modal": "^3.11.2",
-        "react-popper": "^2.2.3",
-        "react-select": "^5.3.0",
-        "react-table": "^7.7.0",
-        "react-textarea-autosize": "^7.1.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/plaid-threads/node_modules/react-textarea-autosize": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
-      "integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "prop-types": "^15.6.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0 <17.0.0"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3496,15 +3138,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/prism-react-renderer": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=0.14.9"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3535,83 +3168,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "license": "MIT",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
-    "node_modules/rc-align": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.5.tgz",
-      "integrity": "sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "dom-align": "^1.7.0",
-        "prop-types": "^15.5.8",
-        "rc-util": "^4.0.4"
-      }
-    },
-    "node_modules/rc-animate": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.11.1.tgz",
-      "integrity": "sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "css-animation": "^1.3.2",
-        "prop-types": "15.x",
-        "raf": "^3.4.0",
-        "rc-util": "^4.15.3",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "node_modules/rc-calendar": {
-      "version": "9.15.11",
-      "resolved": "https://registry.npmjs.org/rc-calendar/-/rc-calendar-9.15.11.tgz",
-      "integrity": "sha512-qv0VXfAAnysMWJigxaP6se4bJHvr17D9qsLbi8BOpdgEocsS0RkgY1IUiFaOVYKJDy/EyLC447O02sV/y5YYBg==",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "classnames": "2.x",
-        "moment": "2.x",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.0",
-        "rc-util": "^4.1.1",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "node_modules/rc-trigger": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.6.5.tgz",
-      "integrity": "sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==",
-      "dependencies": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "prop-types": "15.x",
-        "rc-align": "^2.4.0",
-        "rc-animate": "2.x",
-        "rc-util": "^4.4.0",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "node_modules/rc-util": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
-      "integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
-      "license": "MIT",
-      "dependencies": {
-        "add-dom-event-listener": "^1.1.0",
-        "prop-types": "^15.5.10",
-        "react-is": "^16.12.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3637,39 +3193,11 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "license": "MIT"
-    },
-    "node_modules/react-modal": {
-      "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
-      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "exenv": "^1.2.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
-      }
     },
     "node_modules/react-plaid-link": {
       "version": "4.1.1",
@@ -3682,21 +3210,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-router": {
@@ -3744,27 +3257,6 @@
         "react-router-dom": ">=4"
       }
     },
-    "node_modules/react-select": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
-      "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "@emotion/cache": "^11.4.0",
-        "@emotion/react": "^11.8.1",
-        "@floating-ui/dom": "^1.0.1",
-        "@types/react-transition-group": "^4.4.0",
-        "memoize-one": "^6.0.0",
-        "prop-types": "^15.6.0",
-        "react-transition-group": "^4.3.0",
-        "use-isomorphic-layout-effect": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -3778,19 +3270,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-table": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
-      "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0"
       }
     },
     "node_modules/react-toastify": {
@@ -3873,37 +3352,11 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "license": "MIT"
-    },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3913,7 +3366,6 @@
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
@@ -3947,7 +3399,6 @@
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -3978,12 +3429,6 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4036,15 +3481,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4067,12 +3503,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4084,18 +3514,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/synckit": {
@@ -4114,11 +3532,24 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -4130,7 +3561,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4147,7 +3577,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -4182,7 +3611,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -4193,20 +3622,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/victory-vendor": {
@@ -4235,7 +3650,6 @@
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -4309,15 +3723,6 @@
         }
       }
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4377,7 +3782,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,

--- a/client/package.json
+++ b/client/package.json
@@ -4,13 +4,13 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "axios": "^1.13.5",
     "date-fns": "^4.1.0",
     "immer": "10.2.0",
     "plaid": "^41.1.0",
-    "plaid-threads": "14.5.0",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -20,7 +20,8 @@
     "react-toastify": "^10.0.6",
     "recharts": "^2.15.0",
     "sass": "^1.97.3",
-    "socket.io-client": "^4.8.3"
+    "socket.io-client": "^4.8.3",
+    "tailwindcss": "^4.2.2"
   },
   "scripts": {
     "dev": "vite",

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1,8 +1,19 @@
-$threads-font-path: 'plaid-threads/fonts';
-@import 'plaid-threads/scss/typography';
-@import 'plaid-threads/scss/variables';
+$white: #ffffff;
+$black100: #fafafa;
+$black200: #f6f6f6;
+$black400: #dcdcdc;
+$black600: #949494;
+$black1000: #111111;
+$red800: #f44e66;
+$blue600: #63daff;
 
+$unit: 0.8rem;
 $border: 1px solid $black200;
+$border-radius: 0.2rem;
+$shadow-xsmall: 0 0.2rem 0.4rem 0 rgba(17, 17, 17, 0.08);
+$shadow-medium: 0 0.8rem 1.6rem 0 rgba(17, 17, 17, 0.08);
+$font-stack-monospace: Inconsolata, Consolas, Courier, monospace;
+
 /*
 
 
@@ -99,9 +110,9 @@ Content at the top of the view
 }
 
 .everpresent-content__subheading {
-  font-size: 3 * $unit;
+  font-size: 1.1rem;
   font-weight: 300;
-  line-height: 4 * $unit;
+  line-height: 1.6;
   margin-bottom: 0;
 }
 
@@ -128,80 +139,6 @@ Landing overview
 
 .btnWithMargin {
   margin-left: 2 * $unit;
-}
-
-/*
-
-Modal
-
-*/
-
-// Fix modal overlay transparency issues
-// Target both ReactModal default classes and plaid-threads custom classes
-.ReactModal__Overlay,
-[class*="modalPortalOverlay"] {
-  background-color: rgba(0, 0, 0, 0.6) !important;
-  z-index: 1000 !important;
-  position: fixed !important;
-  top: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  bottom: 0 !important;
-  display: flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-}
-
-.ReactModal__Content,
-[class*="modalPortalContent"] {
-  background: $white !important;
-  border: none !important;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15) !important;
-  border-radius: $border-radius !important;
-  max-width: 500px;
-  width: 90%;
-  max-height: 90vh;
-  overflow: auto;
-  z-index: 1001 !important;
-  position: relative !important;
-  inset: auto !important;
-  transform: none !important;
-  padding: 0 !important;
-}
-
-// Additional override for modal portal container
-[class*="modalPortal"] {
-  z-index: 2000 !important;
-}
-
-// Make input fields visible and styled properly
-input[type="text"],
-input[type="password"],
-input[type="email"],
-textarea {
-  background: $white !important;
-  border: 1px solid $black400 !important;
-  border-radius: 4px !important;
-  padding: 12px !important;
-  font-size: 16px !important;
-  width: 100% !important;
-  box-sizing: border-box !important;
-  transition: border-color 0.2s !important;
-
-  &:focus {
-    outline: none !important;
-    border-color: $blue600 !important;
-    box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.1) !important;
-  }
-
-  &::placeholder {
-    color: $black600 !important;
-    opacity: 0.7 !important;
-  }
-}
-
-input::placeholder {
-  line-height: 1.5;
 }
 
 /*
@@ -344,11 +281,11 @@ Add User Form
 }
 
 .add-user__heading {
-  font-size: 2 * $unit;
+  font-size: 1rem;
 }
 
 .add-user__value {
-  font-size: 1.4rem;
+  font-size: 0.875rem;
 }
 
 .add-user__column-2 {
@@ -448,10 +385,8 @@ net worth
 }
 
 .netWorthText {
-  font-family: $font-stack-monospace;
-  font-size: 2 * $unit;
-  letter-spacing: 1px;
-  text-transform: uppercase;
+  font-size: 1rem;
+  color: $black600;
 }
 
 .netWorthContainer {
@@ -530,10 +465,8 @@ Monthly Spending
 
 .monthlySpendingText {
   margin-bottom: 4 * $unit;
-  font-family: $font-stack-monospace;
-  font-size: 2 * $unit;
-  letter-spacing: 1px;
-  text-transform: uppercase;
+  font-size: 1rem;
+  color: $black600;
 }
 .recharts-wrapper {
   margin: 0 2 * $unit;

--- a/client/src/components/AccountCard.tsx
+++ b/client/src/components/AccountCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import startCase from 'lodash/startCase';
 import toLower from 'lodash/toLower';
-import { Button } from 'plaid-threads/Button';
+import { Button } from './ui/Button.tsx';
 
 import { AccountType } from './types';
 import useTransactions from '../services/transactions.tsx';
@@ -48,7 +48,7 @@ export default function AccountCard(props: Props) {
         </div>
         <div className="account-data-row__right">
           {transactions.length !== 0 && (
-            <Button onClick={toggleShowTransactions} centered small inline>
+            <Button onClick={toggleShowTransactions} small secondary>
               {transactionsShown ? 'Hide Transactions' : 'View Transactions'}
             </Button>
           )}

--- a/client/src/components/AddUserForm.tsx
+++ b/client/src/components/AddUserForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Button } from 'plaid-threads/Button';
-import { TextInput } from 'plaid-threads/TextInput';
+import { Button } from './ui/Button.tsx';
+import { TextInput } from './ui/TextInput.tsx';
 
 import { useUsers, useCurrentUser } from '../services';
 
@@ -42,17 +42,16 @@ const AddUserForm = (props: Props) => {
               className="input_field"
               value={username}
               placeholder="New user name"
-              label="User_Name"
+              label=""
               onChange={e => setUsername(e.target.value)}
             />
           </div>
           <div className="add-user__column-3">
-            <Button className="add-user__button" centered small type="submit">
+            <Button className="add-user__button" small type="submit">
               Add User
             </Button>
             <Button
               className="add-user__button"
-              centered
               small
               secondary
               onClick={props.hideForm}

--- a/client/src/components/Asset.tsx
+++ b/client/src/components/Asset.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { Modal } from 'plaid-threads/Modal';
-import { ModalBody } from 'plaid-threads/ModalBody';
-import { Button } from 'plaid-threads/Button';
-import { TextInput } from 'plaid-threads/TextInput';
-import { NumberInput } from 'plaid-threads/NumberInput';
+import { Modal } from './ui/Modal.tsx';
+import { ModalBody } from './ui/ModalBody.tsx';
+import { Button } from './ui/Button.tsx';
+import { TextInput } from './ui/TextInput.tsx';
 
 import { useAssets } from '../services';
 
@@ -29,39 +28,38 @@ export default function Asset(props: Props) {
 
   return (
     <div className="assetBtnContainer">
-      <Button centered inline small secondary onClick={() => setShow(!show)}>
+      <Button small secondary onClick={() => setShow(!show)}>
         Add An Asset
       </Button>
       <Modal isOpen={show} onRequestClose={() => setShow(false)}>
-        <>
-          <ModalBody
-            header="Enter Your Asset"
-            isLoading={false}
-            onClickCancel={() => setShow(false)}
-          >
-            <form onSubmit={handleSubmit}>
-              <TextInput
-                required
-                label=""
-                id="id-6"
-                placeholder="Enter Asset Description (e.g. house or car)"
-                value={description}
-                onChange={e => setDescription(e.currentTarget.value)}
-              />
-              <NumberInput
-                required
-                label=""
-                id="id-6"
-                placeholder="Enter Asset Value (in dollars $)"
-                value={value}
-                onChange={e => setValue(e.currentTarget.value)}
-              />
-              <Button wide type="submit">
-                Submit
-              </Button>
-            </form>
-          </ModalBody>
-        </>
+        <ModalBody
+          header="Enter Your Asset"
+          isLoading={false}
+          onClickCancel={() => setShow(false)}
+        >
+          <form onSubmit={handleSubmit}>
+            <TextInput
+              required
+              label=""
+              id="asset-description"
+              placeholder="Enter Asset Description (e.g. house or car)"
+              value={description}
+              onChange={e => setDescription(e.currentTarget.value)}
+            />
+            <TextInput
+              required
+              label=""
+              id="asset-value"
+              type="number"
+              placeholder="Enter Asset Value (in dollars $)"
+              value={value}
+              onChange={e => setValue(e.currentTarget.value)}
+            />
+            <Button wide type="submit">
+              Submit
+            </Button>
+          </form>
+        </ModalBody>
       </Modal>
     </div>
   );

--- a/client/src/components/Banner.tsx
+++ b/client/src/components/Banner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from 'plaid-threads/Button';
+import { Button } from './ui/Button.tsx';
 
 const PLAID_ENV = import.meta.env.VITE_PLAID_ENV;
 
@@ -25,8 +25,6 @@ const Banner = (props: Props) => {
           href="https://docs.google.com/forms/d/e/1FAIpQLSfF4Xev5w9RPGr7fNkSHjmtE_dj0ELuHRbDexQ7Tg2xoo6tQg/viewform"
           target="_blank"
           rel="noopener noreferrer"
-          inline
-          centered
           secondary
         >
           Provide feedback on this Plaid Pattern sample app

--- a/client/src/components/CategoriesChart.tsx
+++ b/client/src/components/CategoriesChart.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PieChart, Pie, Cell, Legend } from 'recharts';
-import colors from 'plaid-threads/scss/colors.ts';
+import colors from '../lib/colors.ts';
 
 interface Props {
   categories: {

--- a/client/src/components/ErrorMessage.tsx
+++ b/client/src/components/ErrorMessage.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { Callout } from 'plaid-threads/Callout';
-import { IconButton } from 'plaid-threads/IconButton';
-import { CloseS2 } from 'plaid-threads/Icons/CloseS2';
+import { Callout } from './ui/Callout.tsx';
+import { IconButton } from './ui/IconButton.tsx';
+import { CloseIcon } from './ui/icons.tsx';
 
 import useErrors from '../services/errors.tsx';
-
-//  Allows user to input their personal assets such as a house or car.
 
 export default function ErrorMessage() {
   const [show, setShow] = useState(false);
@@ -44,7 +42,7 @@ export default function ErrorMessage() {
               setShow(false);
               resetError();
             }}
-            icon={<CloseS2 />}
+            icon={<CloseIcon />}
           />
           <div>
             <strong>Connection Error:</strong> {error.code}

--- a/client/src/components/ItemCard.tsx
+++ b/client/src/components/ItemCard.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Note } from 'plaid-threads/Note';
-import { Touchable } from 'plaid-threads/Touchable';
-import { InlineLink } from 'plaid-threads/InlineLink';
-import { Callout } from 'plaid-threads/Callout';
-import { Button } from 'plaid-threads/Button';
 import { Institution } from 'plaid/dist/api';
 import { toast } from 'react-toastify';
+
+import { Button } from './ui/Button.tsx';
+import { Callout } from './ui/Callout.tsx';
 
 import { ItemType, AccountType } from './types';
 import AccountCard from './AccountCard.tsx';
@@ -124,8 +122,9 @@ const ItemCard = (props: Props) => {
   return (
     <div className="box">
       <div className={cardClassNames}>
-        <Touchable
-          className="item-card__clickable"
+        <button
+          type="button"
+          className="item-card__clickable cursor-pointer bg-transparent border-none text-left"
           onClick={() => setShowAccounts(current => !current)}
         >
           <div className="item-card__column-1">
@@ -138,13 +137,13 @@ const ItemCard = (props: Props) => {
           </div>
           <div className="item-card__column-2">
             {isGoodState ? (
-              <Note info solid>
+              <span className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-blue-400 text-blue-900">
                 Updated
-              </Note>
+              </span>
             ) : (
-              <Note error solid>
+              <span className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-red-200 text-red-900">
                 Login Required
-              </Note>
+              </span>
             )}
             <Button
               small
@@ -162,7 +161,7 @@ const ItemCard = (props: Props) => {
               {diffBetweenCurrentTime(props.item.updated_at)}
             </p>
           </div>
-        </Touchable>
+        </button>
         <MoreDetails // The MoreDetails component allows developer to test the ITEM_LOGIN_REQUIRED webhook and Link update mode
           setBadStateShown={isSandbox && isGoodState}
           handleDelete={handleDeleteItem}
@@ -183,10 +182,13 @@ const ItemCard = (props: Props) => {
       {showAccounts && accounts.length === 0 && (
         <Callout>
           No transactions or accounts have been retrieved for this item. See the{' '}
-          <InlineLink href="https://github.com/plaid/pattern/blob/master/docs/troubleshooting.md">
+          <a
+            className="text-blue-900 underline hover:text-blue-1000"
+            href="https://github.com/plaid/pattern/blob/master/docs/troubleshooting.md"
+          >
             {' '}
             troubleshooting guide{' '}
-          </InlineLink>{' '}
+          </a>{' '}
           to learn about receiving transactions webhooks with this sample app.
         </Callout>
       )}

--- a/client/src/components/Landing.tsx
+++ b/client/src/components/Landing.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Button } from 'plaid-threads/Button';
+import { Button } from './ui/Button.tsx';
 import { useNavigate } from 'react-router-dom';
 
 import useCurrentUser from '../services/currentUser.tsx';
@@ -34,13 +34,11 @@ export default function Landing() {
       </div>
       <div className="btnsContainer" style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
         <Login />
-        <Button onClick={toggleForm} centered inline>
+        <Button onClick={toggleForm}>
           Create Account
         </Button>
         {userState.currentUser.username != null && (
           <Button
-            centered
-            inline
             onClick={returnToCurrentUser}
           >
             Return to Current User

--- a/client/src/components/LoadingCallout.tsx
+++ b/client/src/components/LoadingCallout.tsx
@@ -1,8 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Callout } from 'plaid-threads/Callout';
-import { InlineLink } from 'plaid-threads/InlineLink';
-
-//  Allows user to input their personal assets such as a house or car.
+import { Callout } from './ui/Callout.tsx';
 
 export default function LoadingCallout() {
   const [show, setShow] = useState(false);
@@ -19,10 +16,13 @@ export default function LoadingCallout() {
       {show && (
         <Callout>
           Transactions webhooks not received. See the{' '}
-          <InlineLink href="https://github.com/plaid/pattern/blob/master/docs/troubleshooting.md">
+          <a
+            className="text-blue-900 underline hover:text-blue-1000"
+            href="https://github.com/plaid/pattern/blob/master/docs/troubleshooting.md"
+          >
             {' '}
             troubleshooting guide{' '}
-          </InlineLink>{' '}
+          </a>{' '}
           to learn about receiving transactions webhooks with this sample app.
         </Callout>
       )}

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { Modal } from 'plaid-threads/Modal';
-import { ModalBody } from 'plaid-threads/ModalBody';
-import { Button } from 'plaid-threads/Button';
-import { TextInput } from 'plaid-threads/TextInput';
+import { Modal } from './ui/Modal.tsx';
+import { ModalBody } from './ui/ModalBody.tsx';
+import { Button } from './ui/Button.tsx';
+import { TextInput } from './ui/TextInput.tsx';
 
 import { useCurrentUser } from '../services';
 
@@ -18,7 +18,7 @@ const Login = () => {
 
   return (
     <>
-      <Button centered inline onClick={() => setShow(!show)}>
+      <Button onClick={() => setShow(!show)}>
         Login
       </Button>
       {show && (
@@ -36,7 +36,7 @@ const Login = () => {
               placeholder="Enter User Name"
               value={value}
               onChange={e => setValue(e.currentTarget.value)}
-              onKeyPress={e => {
+              onKeyDown={e => {
                 if (e.key === 'Enter') {
                   handleSubmit();
                 }

--- a/client/src/components/MoreDetails.tsx
+++ b/client/src/components/MoreDetails.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { MenuS1 as Menu } from 'plaid-threads/Icons/MenuS1';
-import { Dropdown } from 'plaid-threads/Dropdown';
-import { IconButton } from 'plaid-threads/IconButton';
-import { Touchable } from 'plaid-threads/Touchable';
+import { MenuIcon } from './ui/icons.tsx';
+import { IconButton } from './ui/IconButton.tsx';
 
 import LaunchLink from './LaunchLink.tsx';
 import useOnClickOutside from '../hooks/useOnClickOutside.ts';
@@ -45,15 +43,15 @@ export function MoreDetails(props: Props) {
   const linkChoice = props.setBadStateShown ? (
     // handleSetBadState uses sandbox/item/reset_login to send the ITEM_LOGIN_REQUIRED webhook;
     // app responds to this webhook by setting item to "bad" state (server/webhookHandlers/handleItemWebhook.js)
-    <Touchable className="menuOption" onClick={props.handleSetBadState}>
+    <button className="menuOption block w-full text-left px-4 py-2 hover:bg-black-200 cursor-pointer" onClick={props.handleSetBadState}>
       Test Item Login Required Webhook
-    </Touchable>
+    </button>
   ) : (
     // item is in "bad" state;  launch link to login and return to "good" state
     <div>
-      <Touchable className="menuOption" onClick={initiateLink}>
+      <button className="menuOption block w-full text-left px-4 py-2 hover:bg-black-200 cursor-pointer" onClick={initiateLink}>
         Update Login
-      </Touchable>
+      </button>
       {token != null && token.length > 0 && (
         <LaunchLink userId={props.userId} itemId={props.itemId} token={token} />
       )}
@@ -64,7 +62,7 @@ export function MoreDetails(props: Props) {
     <div className="icon-button-container" ref={refToButton}>
       <IconButton
         accessibilityLabel="Navigation"
-        icon={<Menu />}
+        icon={<MenuIcon />}
         onClick={() => setmenuShown(!menuShown)}
       />
     </div>
@@ -72,13 +70,15 @@ export function MoreDetails(props: Props) {
 
   return (
     <div className="more-details" ref={refToMenu}>
-      <Dropdown isOpen={menuShown} target={icon}>
-        {linkChoice}
-
-        <Touchable className="menuOption2" onClick={props.handleDelete}>
-          Remove
-        </Touchable>
-      </Dropdown>
+      {icon}
+      {menuShown && (
+        <div className="absolute right-0 top-full z-10 bg-white border border-black-300 rounded shadow-md min-w-[200px]">
+          {linkChoice}
+          <button className="menuOption2 block w-full text-left px-4 py-2 hover:bg-black-200 cursor-pointer" onClick={props.handleDelete}>
+            Remove
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/NetWorth.tsx
+++ b/client/src/components/NetWorth.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { IconButton } from 'plaid-threads/IconButton';
-import { Trash } from 'plaid-threads/Icons/Trash';
+import { IconButton } from './ui/IconButton.tsx';
+import { TrashIcon } from './ui/icons.tsx';
 
 import { currencyFilter, pluralize } from '../util/index.tsx';
 import Asset from './Asset.tsx';
@@ -86,8 +86,8 @@ export default function NetWorth(props: Props) {
                       <p className="dataItem">{currencyFilter(asset.value)}</p>
                       <p>
                         <IconButton
-                          accessibilityLabel="Navigation"
-                          icon={<Trash />}
+                          accessibilityLabel="Delete asset"
+                          icon={<TrashIcon />}
                           onClick={() => {
                             handleDelete(asset.id, props.userId);
                           }}
@@ -143,8 +143,8 @@ export default function NetWorth(props: Props) {
                       <p className="dataItem">{currencyFilter(asset.value)}</p>
                       <p>
                         <IconButton
-                          accessibilityLabel="Navigation"
-                          icon={<Trash />}
+                          accessibilityLabel="Delete asset"
+                          icon={<TrashIcon />}
                           onClick={() => {
                             handleDelete(asset.id, props.userId);
                           }}

--- a/client/src/components/UserCard.tsx
+++ b/client/src/components/UserCard.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { HashLink } from 'react-router-hash-link';
-import { Button } from 'plaid-threads/Button';
-import { Touchable } from 'plaid-threads/Touchable';
+import { Button } from './ui/Button.tsx';
 
 import UserDetails from './UserDetails.tsx';
 import LaunchLink from './LaunchLink.tsx';
@@ -70,9 +69,8 @@ export default function UserCard(props: Props) {
             setHovered(false);
           }}
         >
-          <Touchable
-            className="user-card-clickable"
-            component={HashLink}
+          <HashLink
+            className="user-card-clickable no-underline text-inherit"
             to={`/user/${props.userId}#itemCards`}
           >
             <div className="user-card__detail">
@@ -82,14 +80,13 @@ export default function UserCard(props: Props) {
                 numOfItems={numOfItems}
               />
             </div>
-          </Touchable>
+          </HashLink>
         </div>
         {(props.removeButton || (props.linkButton && numOfItems === 0)) && (
           <div className="user-card__buttons">
             {props.linkButton && numOfItems === 0 && (
               <Button
                 large
-                inline
                 className="add-account__button"
                 onClick={initiateLink}
               >
@@ -107,8 +104,6 @@ export default function UserCard(props: Props) {
                 className="remove"
                 onClick={handleDeleteUser}
                 small
-                inline
-                centered
                 secondary
               >
                 Delete user

--- a/client/src/components/UserPage.tsx
+++ b/client/src/components/UserPage.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import sortBy from 'lodash/sortBy';
-import { SecondaryLink as NavigationLink } from 'plaid-threads/SecondaryLink';
-import { LoadingSpinner } from 'plaid-threads/LoadingSpinner';
-import { Callout } from 'plaid-threads/Callout';
-import { Button } from 'plaid-threads/Button';
+import { LoadingSpinner } from './ui/LoadingSpinner.tsx';
+import { Callout } from './ui/Callout.tsx';
+import { Button } from './ui/Button.tsx';
 
 import { RouteInfo, ItemType, AccountType, AssetType } from './types';
 
@@ -130,9 +129,9 @@ const UserPage = () => {
   document.getElementsByTagName('body')[0].style.overflow = 'auto'; // to override overflow:hidden from link pane
   return (
     <div>
-      <NavigationLink component={Link} to="/">
+      <Link to="/" className="text-sm text-black-700 uppercase tracking-wider hover:text-black-1000 no-underline">
         BACK TO LOGIN
-      </NavigationLink>
+      </Link>
 
       <Banner />
       {linkTokens.error.error_code != null && (
@@ -156,7 +155,7 @@ const UserPage = () => {
 
       <Callout style={{ marginBottom: '2rem' }}>
         <div>
-          <strong>💡 Testing with Dynamic Transaction Data:</strong>
+          <strong>Testing with Dynamic Transaction Data:</strong>
         </div>
         <div style={{ marginTop: '8px' }}>
           To test with realistic data, link a <strong>non-OAuth institution</strong> like{' '}
@@ -193,7 +192,6 @@ const UserPage = () => {
 
             <Button
               large
-              inline
               className="add-account__button"
               onClick={initiateLink}
             >

--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  small?: boolean;
+  large?: boolean;
+  secondary?: boolean;
+  wide?: boolean;
+  href?: string;
+  target?: string;
+  rel?: string;
+  children: React.ReactNode;
+}
+
+export function Button({
+  small,
+  large,
+  secondary,
+  wide,
+  href,
+  target,
+  rel,
+  className = '',
+  children,
+  ...rest
+}: ButtonProps) {
+  const base =
+    'inline-flex items-center justify-center rounded font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-800 focus:ring-offset-2 cursor-pointer';
+  const size = small
+    ? 'px-3 py-1 text-sm'
+    : large
+      ? 'px-6 py-3 text-lg'
+      : 'px-4 py-2 text-base';
+  const variant = secondary
+    ? 'border border-black-400 bg-white text-black-900 hover:bg-black-200'
+    : 'bg-black-1000 text-white hover:bg-black-900';
+  const width = wide ? 'w-full' : '';
+  const disabledStyle = rest.disabled ? 'opacity-50 cursor-not-allowed' : '';
+
+  const classes = [base, size, variant, width, disabledStyle, className]
+    .filter(Boolean)
+    .join(' ');
+
+  if (href) {
+    return (
+      <a href={href} target={target} rel={rel} className={classes} aria-disabled={rest.disabled || undefined}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button className={classes} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/client/src/components/ui/Callout.tsx
+++ b/client/src/components/ui/Callout.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface CalloutProps {
+  warning?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+export function Callout({ warning, className = '', style, children }: CalloutProps) {
+  const base = 'rounded border p-4 text-sm';
+  const variant = warning
+    ? 'bg-yellow-200 border-yellow-600 text-black-900'
+    : 'bg-blue-200 border-blue-600 text-black-900';
+
+  return (
+    <div className={`${base} ${variant} ${className}`} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/client/src/components/ui/IconButton.tsx
+++ b/client/src/components/ui/IconButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface IconButtonProps {
+  accessibilityLabel: string;
+  icon: React.ReactNode;
+  onClick?: (e: React.MouseEvent) => void;
+  className?: string;
+}
+
+export function IconButton({ accessibilityLabel, icon, onClick, className = '' }: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={accessibilityLabel}
+      onClick={onClick}
+      className={`inline-flex items-center justify-center p-1 rounded hover:bg-black-200 transition-colors cursor-pointer ${className}`}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/client/src/components/ui/LoadingSpinner.tsx
+++ b/client/src/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function LoadingSpinner() {
+  return (
+    <div className="flex justify-center" role="status" aria-label="Loading">
+      <div className="animate-spin h-10 w-10 border-4 border-black-300 border-t-black-1000 rounded-full" />
+    </div>
+  );
+}

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+interface ModalProps {
+  isOpen: boolean;
+  onRequestClose: () => void;
+  children: React.ReactNode;
+}
+
+export function Modal({ isOpen, onRequestClose, children }: ModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onRequestClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, onRequestClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onRequestClose();
+      }}
+    >
+      <div role="dialog" aria-modal="true" className="bg-white rounded shadow-md max-w-[500px] w-[90%] max-h-[90vh] overflow-auto relative z-[1001]">
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/client/src/components/ui/ModalBody.tsx
+++ b/client/src/components/ui/ModalBody.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Button } from './Button.tsx';
+
+interface ModalBodyProps {
+  header: string;
+  isLoading?: boolean;
+  onClickCancel?: () => void;
+  onClickConfirm?: () => void;
+  confirmText?: string;
+  children: React.ReactNode;
+}
+
+export function ModalBody({
+  header,
+  isLoading,
+  onClickCancel,
+  onClickConfirm,
+  confirmText = 'Confirm',
+  children,
+}: ModalBodyProps) {
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-semibold mb-4">{header}</h2>
+      {isLoading ? (
+        <div className="flex justify-center py-8" role="status" aria-label="Loading">
+          <div className="animate-spin h-8 w-8 border-4 border-black-300 border-t-black-1000 rounded-full" />
+        </div>
+      ) : (
+        <>
+          <div className="mb-4">{children}</div>
+          {(onClickCancel || onClickConfirm) && (
+            <div className="flex justify-end gap-3">
+              {onClickCancel && (
+                <Button secondary onClick={onClickCancel}>
+                  Cancel
+                </Button>
+              )}
+              {onClickConfirm && (
+                <Button onClick={onClickConfirm}>{confirmText}</Button>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ui/TextInput.tsx
+++ b/client/src/components/ui/TextInput.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+export function TextInput({ label, id, type = 'text', className = '', ...rest }: TextInputProps) {
+  return (
+    <div className={`mb-3 ${className}`}>
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-black-800 mb-1">
+          {label}
+        </label>
+      )}
+      <input
+        type={type}
+        id={id}
+        className="w-full border border-black-400 rounded px-3 py-2 text-base bg-white focus:outline-none focus:border-blue-800 focus:ring-1 focus:ring-blue-800 placeholder:text-black-600 placeholder:opacity-70 transition-colors"
+        {...rest}
+      />
+    </div>
+  );
+}

--- a/client/src/components/ui/icons.tsx
+++ b/client/src/components/ui/icons.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export function CloseIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+export function TrashIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    </svg>
+  );
+}
+
+export function MenuIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="1" />
+      <circle cx="12" cy="5" r="1" />
+      <circle cx="12" cy="19" r="1" />
+    </svg>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,79 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-white: #ffffff;
+  --color-black-100: #fafafa;
+  --color-black-200: #f6f6f6;
+  --color-black-300: #ededed;
+  --color-black-400: #dcdcdc;
+  --color-black-500: #c5c5c5;
+  --color-black-600: #949494;
+  --color-black-700: #767676;
+  --color-black-800: #555555;
+  --color-black-900: #383838;
+  --color-black-1000: #111111;
+  --color-blue-200: #d4f9ff;
+  --color-blue-400: #b1eefc;
+  --color-blue-600: #63daff;
+  --color-blue-800: #0a85ea;
+  --color-blue-900: #0072cf;
+  --color-blue-1000: #0061b3;
+  --color-green-200: #d0fce4;
+  --color-green-400: #abffdb;
+  --color-green-600: #5befbd;
+  --color-green-800: #23d09c;
+  --color-green-900: #1fa077;
+  --color-yellow-200: #fefbb8;
+  --color-yellow-400: #fbf1a0;
+  --color-yellow-600: #fce76b;
+  --color-yellow-800: #f2d211;
+  --color-yellow-900: #e6ba23;
+  --color-red-200: #ffd7dc;
+  --color-red-400: #ffaab9;
+  --color-red-600: #ff7885;
+  --color-red-800: #f44e66;
+  --color-red-900: #d83d57;
+  --color-purple-200: #e1e1ff;
+  --color-purple-400: #c6befc;
+  --color-purple-600: #9986f7;
+  --color-purple-800: #7646ec;
+  --color-purple-900: #5c2ec7;
+
+  --font-mono: Inconsolata, Consolas, Courier, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+    sans-serif;
+
+  --shadow-xs: 0 0.2rem 0.4rem 0 rgba(17, 17, 17, 0.08);
+  --shadow-sm: 0 0.8rem 0.8rem 0 rgba(17, 17, 17, 0.08);
+  --shadow-md: 0 0.8rem 1.6rem 0 rgba(17, 17, 17, 0.08);
+  --shadow-lg: 0 1.6rem 2.4rem 0 rgba(17, 17, 17, 0.08);
+}
+
+/* Restore heading styles stripped by Tailwind preflight */
+h1 {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+h3 {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -1,8 +1,0 @@
-$threads-font-path: 'plaid-threads/fonts';
-@import 'plaid-threads/scss/typography';
-@import 'plaid-threads/scss/variables';
-
-body {
-  margin: 0;
-  padding: 0;
-}

--- a/client/src/lib/colors.ts
+++ b/client/src/lib/colors.ts
@@ -1,0 +1,10 @@
+const colors = {
+  yellow900: '#e6ba23',
+  red900: '#d83d57',
+  blue900: '#0072cf',
+  green900: '#1fa077',
+  black1000: '#111111',
+  purple600: '#9986f7',
+};
+
+export default colors;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
-import './index.scss';
+import './index.css';
 import App from './App.tsx';
 
 const root = createRoot(document.getElementById('root')!);

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   server: {
     host: true,
     port: 3001,


### PR DESCRIPTION
## Summary

- Replace `plaid-threads` (Plaid's internal component library) with Tailwind CSS v4, matching the approach used by newer Plaid sample apps (`layer-quickstart`, `credit-quickstart`)
- Create lightweight UI wrapper components (`Button`, `TextInput`, `Modal`, `ModalBody`, `Callout`, `IconButton`, `LoadingSpinner`) to replace plaid-threads equivalents
- Migrate all 16 component files and SCSS from plaid-threads imports to Tailwind
- Net dependency reduction: **~100 MB removed** (highcharts, libphonenumber-js, moment-timezone, etc.), ~4 MB added

## Test plan

- [x] `vite build` passes with no errors
- [x] Landing page renders correctly (banner, buttons, login modal, create account form)
- [x] Login modal opens/closes, handles escape key and overlay click
- [x] User page renders with correct heading hierarchy
- [x] Spending insights, net worth, and item cards display correctly
- [x] No remaining `plaid-threads` imports in codebase
- [x] Manual test: create user, link bank via Plaid Link, verify transactions flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: d8cf2f7a-c448-455e-a1ba-99c688e537a6