### PR TITLE
Reduce toast font size and add ngrok inspector link

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -90,7 +90,7 @@ shared styles
 
 .toast__body {
   color: $black1000;
-  font-size: 2 * $unit;
+  font-size: 1rem;
   white-space: pre-line;
   padding-left: $unit;
 }

--- a/client/src/components/UserPage.tsx
+++ b/client/src/components/UserPage.tsx
@@ -166,6 +166,13 @@ const UserPage = () => {
           (any password). The "Refresh Transactions" button will trigger simulated transaction updates.
           See the README for more information about testing with realistic transaction data.
         </div>
+        <div style={{ marginTop: '8px' }}>
+          View incoming webhooks at{' '}
+          <a href="http://localhost:4040" target="_blank" rel="noopener noreferrer">
+            localhost:4040
+          </a>
+          .
+        </div>
       </Callout>
 
       {numOfItems === 0 && <ErrorMessage />}


### PR DESCRIPTION
## Summary
- Reduce toast notification font size from 1.6rem to 1rem — the previous size was comically large
- Add a link to the ngrok webhook inspector (localhost:4040) in the testing callout on the user page, so developers can easily view incoming webhook details

## Test plan
- [ ] Trigger a toast (e.g. click "Refresh Transactions") and verify the text is reasonably sized
- [ ] Verify the "localhost:4040" link appears in the testing callout on the user page
- [ ] Click the link and confirm it opens the ngrok inspector in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 6c37be24-fabc-4e72-96dc-827ce4b7e635