### PR TITLE
Fix Makefile db targets to use plaid_pattern database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,16 @@ install: $(envfile)
 
 ## Initialize the database (create tables)
 db-create:
-	psql -U postgres -f database/init/create.sql
+	psql -U postgres -c 'CREATE DATABASE plaid_pattern' 2>/dev/null; psql -U postgres -d plaid_pattern -f database/init/create.sql
 
 ## Drop and recreate the database
 db-reset:
-	psql -U postgres -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+	psql -U postgres -c 'DROP DATABASE IF EXISTS plaid_pattern'
 	$(MAKE) db-create
 
 ## Start an interactive psql session
 sql:
-	psql -U postgres
+	psql -U postgres -d plaid_pattern
 
 ## Start the server (port 5001)
 server: $(envfile)


### PR DESCRIPTION
## Summary

- Missed in #353 — the Makefile `db-create`, `db-reset`, and `sql` targets were still targeting the default `postgres` database
- `db-create` and `db-reset` now match the `package.json` scripts
- `sql` now opens a session in `plaid_pattern` instead of the default database

## Test plan

- [ ] `make db-create` creates/initializes `plaid_pattern`
- [ ] `make db-reset` drops and reinitializes `plaid_pattern`
- [ ] `make sql` opens a psql session in `plaid_pattern`

🤖 Generated with [Claude Code](https://claude.com/claude-code)