### PR TITLE
Remove dead pattern.plaid.com demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Plaid Pattern client][client-img]
 
-This is a sample Personal Finance Manager application demonstrating an end-to-end [Plaid][plaid] integration, focused on linking items and fetching transaction data. You can view a simplified version of this demonstration app at [pattern.plaid.com](https://pattern.plaid.com).
+This is a sample Personal Finance Manager application demonstrating an end-to-end [Plaid][plaid] integration, focused on linking items and fetching transaction data.
 
 You may also be interested in the [Plaid Transactions tutorial sample app](https://github.com/plaid/tutorial-resources/tree/main/transactions) which has an accompanying [YouTube video tutorial](https://www.youtube.com/watch?v=hBiKJ6vTa4g).
 


### PR DESCRIPTION
\`pattern.plaid.com\` no longer resolves consistently (its CNAME points at a defunct Heroku review-app, \`tranquil-taiga-6307.herokuspace.com\`), and connections fail when it does resolve. Dropping the "view a simplified version of this demo at pattern.plaid.com" sentence; the rest of the README still walks through running the demo locally.

If we want to stand up a hosted version again later, easy to re-add.

## Test plan
- [ ] On the rendered README, confirm the opening paragraph reads cleanly without the demo-link sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c