### PR TITLE
Bump morgan to 1.11.0 in server

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,7 @@
         "express": "^4.22.1",
         "express-promise-router": "^4.1.1",
         "lodash": "^4.17.23",
-        "morgan": "~1.10.1",
+        "morgan": "~1.11.0",
         "pg": "^8.18.0",
         "plaid": "^42.1.0",
         "socket.io": "^4.8.3"
@@ -2987,19 +2987,23 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
+        "on-finished": "~2.4.1",
         "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/morgan/node_modules/debug": {
@@ -3016,18 +3020,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "express": "^4.22.1",
     "express-promise-router": "^4.1.1",
     "lodash": "^4.17.23",
-    "morgan": "~1.10.1",
+    "morgan": "~1.11.0",
     "pg": "^8.18.0",
     "plaid": "^42.1.0",
     "socket.io": "^4.8.3"


### PR DESCRIPTION
Clears the one remaining open Dependabot alert in this repo. The `~1.10.1` pin excluded the patched `1.11.0`, so the moderate `on-finished` advisory stayed open; widening to `~1.11.0` (semver-minor, non-breaking) resolves it. 0 vulnerabilities after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)