### PR TITLE
Upgrade react-plaid-link to 5.0.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,7 +19,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-plaid-link": "^4.1.1",
+        "react-plaid-link": "^5.0.0",
         "react-router-dom": "^6.30.3",
         "react-router-hash-link": "^2.4.3",
         "react-toastify": "^11.1.0",
@@ -3268,9 +3268,9 @@
       "peer": true
     },
     "node_modules/react-plaid-link": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-4.1.1.tgz",
-      "integrity": "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-5.0.0.tgz",
+      "integrity": "sha512-DZ/6C7hf+xhEIG9ElCqjk1lty/z+y+wQuV/A29EUx4fxiPLPe7CXN811C3MrCzI7grV45LD7NRS0Do0ma8KIBg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-plaid-link": "^4.1.1",
+    "react-plaid-link": "^5.0.0",
     "react-router-dom": "^6.30.3",
     "react-router-hash-link": "^2.4.3",
     "react-toastify": "^11.1.0",

--- a/client/src/components/LaunchLink.tsx
+++ b/client/src/components/LaunchLink.tsx
@@ -38,7 +38,7 @@ export default function LaunchLink(props: Props) {
 
   // define onSuccess, onExit and onEvent functions as configs for Plaid Link creation
   const onSuccess = async (
-    publicToken: string,
+    publicToken: string | null,
     metadata: PlaidLinkOnSuccessMetadata
   ) => {
     // log and save metatdata
@@ -52,7 +52,7 @@ export default function LaunchLink(props: Props) {
     } else {
       // call to Plaid api endpoint: /item/public_token/exchange in order to obtain access_token which is then stored with the created item
       await exchangeToken(
-        publicToken,
+        publicToken!,
         metadata.institution,
         metadata.accounts,
         props.userId


### PR DESCRIPTION
5.0.0 corrects the public TypeScript definitions to match the Link Web SDK, so this is a types-only upgrade — runtime behavior is unchanged. One corrected definition reaches this app: `onSuccess` now types `public_token` as `string | null`, so `LaunchLink`'s `onSuccess` widens to match and asserts non-null at the `exchangeToken` call, where regular link mode always has a token. Update mode never reached that call.

`client/` has 56 pre-existing type errors on `master` and its build script is `vite build` with no `tsc`, so I verified this by running `tsc` directly and confirming the count is unchanged at 56 — the upgrade added exactly one error, and this diff removes it.