### PR TITLE
Changes: Upgraded @vitejs/plugin-react from 6.0.1 to 6.1.1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -33,7 +33,7 @@
         "@types/node": "^25.6.0",
         "@types/react-router-hash-link": "^2.4.9",
         "@types/socket.io-client": "^3.0.0",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^6.1.1",
         "eslint": "^9.17.0",
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.4.2",
@@ -1410,13 +1410,13 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
-      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz",
+      "integrity": "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "^1.0.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -1424,6 +1424,7 @@
       "peerDependencies": {
         "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
         "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
         "vite": "^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -1431,6 +1432,9 @@
           "optional": true
         },
         "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "oxc-transform-react": {
           "optional": true
         }
       }

--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^25.6.0",
     "@types/react-router-hash-link": "^2.4.9",
     "@types/socket.io-client": "^3.0.0",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@vitejs/plugin-react": "^6.1.1",
     "eslint": "^9.17.0",
     "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.4.2",


### PR DESCRIPTION
The older version (6.0.2 installed) had a bug where $RefreshReg$ calls were injected into compiled JSX but the refresh runtime preamble wasn't injected into the HTML, causing ReferenceError: $RefreshReg$ is not defined which crashed the React app and resulted in a blank page.